### PR TITLE
Fix propagule overgrowth

### DIFF
--- a/common/src/main/java/lol/zanspace/unloadedactivity/mixin/chunk/randomTicks/PropaguleSaplingMixin.java
+++ b/common/src/main/java/lol/zanspace/unloadedactivity/mixin/chunk/randomTicks/PropaguleSaplingMixin.java
@@ -2,19 +2,21 @@ package lol.zanspace.unloadedactivity.mixin.chunk.randomTicks;
 
 import net.minecraft.block.BlockState;
 import net.minecraft.block.PropaguleBlock;
+import net.minecraft.block.SaplingBlock;
+import net.minecraft.block.SaplingGenerator;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.state.property.BooleanProperty;
 import net.minecraft.util.math.BlockPos;
-import net.minecraft.util.math.random.Random;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 
 
 @Mixin(PropaguleBlock.class)
-public abstract class PropaguleSaplingMixin extends SaplingMixin {
-    protected PropaguleSaplingMixin(Settings settings) {
-        super(settings);
+public abstract class PropaguleSaplingMixin extends SaplingBlock {
+
+    protected PropaguleSaplingMixin(SaplingGenerator generator, Settings settings) {
+        super(generator, settings);
     }
 
     @Shadow @Final public static BooleanProperty HANGING;
@@ -25,10 +27,10 @@ public abstract class PropaguleSaplingMixin extends SaplingMixin {
     }
 
     @Override
-    public void simulateRandTicks(BlockState state, ServerWorld world, BlockPos pos, Random random, long timePassed, int randomTickSpeed) {
+    public boolean canSimulateRandTicks(BlockState state, ServerWorld world, BlockPos pos) {
         if (isHanging(state))
-            return;
+            return false;
 
-        super.simulateRandTicks(state, world, pos, random, timePassed, randomTickSpeed);
+        return super.canSimulateRandTicks(state, world, pos);
     }
 }

--- a/common/src/main/java/lol/zanspace/unloadedactivity/mixin/chunk/randomTicks/PropaguleSaplingMixin.java
+++ b/common/src/main/java/lol/zanspace/unloadedactivity/mixin/chunk/randomTicks/PropaguleSaplingMixin.java
@@ -1,0 +1,34 @@
+package lol.zanspace.unloadedactivity.mixin.chunk.randomTicks;
+
+import net.minecraft.block.BlockState;
+import net.minecraft.block.PropaguleBlock;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.state.property.BooleanProperty;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.random.Random;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+
+
+@Mixin(PropaguleBlock.class)
+public abstract class PropaguleSaplingMixin extends SaplingMixin {
+    protected PropaguleSaplingMixin(Settings settings) {
+        super(settings);
+    }
+
+    @Shadow @Final public static BooleanProperty HANGING;
+
+    @Shadow
+    protected static boolean isHanging(BlockState state) {
+        return state.get(HANGING);
+    }
+
+    @Override
+    public void simulateRandTicks(BlockState state, ServerWorld world, BlockPos pos, Random random, long timePassed, int randomTickSpeed) {
+        if (isHanging(state))
+            return;
+
+        super.simulateRandTicks(state, world, pos, random, timePassed, randomTickSpeed);
+    }
+}

--- a/common/src/main/java/lol/zanspace/unloadedactivity/mixin/chunk/randomTicks/SaplingMixin.java
+++ b/common/src/main/java/lol/zanspace/unloadedactivity/mixin/chunk/randomTicks/SaplingMixin.java
@@ -15,6 +15,7 @@ import net.minecraft.state.property.IntProperty;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.random.Random;
 import net.minecraft.world.LightType;
+import net.minecraft.world.World;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -33,6 +34,9 @@ public abstract class SaplingMixin extends PlantBlock {
     @Shadow
     public void generate(ServerWorld world, BlockPos pos, BlockState state, Random random) {
     }
+
+    @Shadow
+    public abstract boolean canGrow(World world, Random random, BlockPos pos, BlockState state);
 
     @Shadow @Final public static IntProperty STAGE;
 
@@ -59,6 +63,10 @@ public abstract class SaplingMixin extends PlantBlock {
 
     @Override
     public void simulateRandTicks(BlockState state, ServerWorld world, BlockPos pos, Random random, long timePassed, int randomTickSpeed) {
+
+        if (!this.canGrow(world, random, pos, state)) {
+            return;
+        }
 
         if (world.getLightLevel(LightType.BLOCK, pos.up()) < 9) { // If there isnt enough block lights we will do a calculation on how many ticks the tree could have spent in sunlight.
             int stopGrowTime = 13027; //stops growing at 12739 ticks when raining, 13027 when no rain

--- a/common/src/main/java/lol/zanspace/unloadedactivity/mixin/chunk/randomTicks/SaplingMixin.java
+++ b/common/src/main/java/lol/zanspace/unloadedactivity/mixin/chunk/randomTicks/SaplingMixin.java
@@ -15,7 +15,6 @@ import net.minecraft.state.property.IntProperty;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.random.Random;
 import net.minecraft.world.LightType;
-import net.minecraft.world.World;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -34,9 +33,6 @@ public abstract class SaplingMixin extends PlantBlock {
     @Shadow
     public void generate(ServerWorld world, BlockPos pos, BlockState state, Random random) {
     }
-
-    @Shadow
-    public abstract boolean canGrow(World world, Random random, BlockPos pos, BlockState state);
 
     @Shadow @Final public static IntProperty STAGE;
 
@@ -63,10 +59,6 @@ public abstract class SaplingMixin extends PlantBlock {
 
     @Override
     public void simulateRandTicks(BlockState state, ServerWorld world, BlockPos pos, Random random, long timePassed, int randomTickSpeed) {
-
-        if (!this.canGrow(world, random, pos, state)) {
-            return;
-        }
 
         if (world.getLightLevel(LightType.BLOCK, pos.up()) < 9) { // If there isnt enough block lights we will do a calculation on how many ticks the tree could have spent in sunlight.
             int stopGrowTime = 13027; //stops growing at 12739 ticks when raining, 13027 when no rain

--- a/common/src/main/resources/unloadedactivity.mixins.json
+++ b/common/src/main/resources/unloadedactivity.mixins.json
@@ -12,6 +12,7 @@
     "chunk.randomTicks.CropMixin",
     "chunk.randomTicks.StemMixin",
     "chunk.randomTicks.SaplingMixin",
+    "chunk.randomTicks.PropaguleSaplingMixin",
     "chunk.randomTicks.SweetBerryBushMixin",
     "chunk.randomTicks.CocoaMixin",
     "chunk.randomTicks.SugarCaneMixin",


### PR DESCRIPTION
This seems to mitigate some of the issue, as some propagule of newly generated mangrove tress generate in valid growing location. This is based on a brief test this morning. Will do a bit more testing later today when I get the time.

Let me know any updates I might need to make.